### PR TITLE
Looking for initial feedback from Dan

### DIFF
--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -22,20 +22,27 @@ interface IOFTWrapper {
         uint8 version;
         address _token;
         address _adapter;
-        uint16 _dstChainId;
+        uint16 _dstEid;
         uint256 _amount;
         uint256 _minAmount;
         bytes32 _toAddress;
         uint256 _nativeDrop;
     }
 
+    struct QuoteFee {
+        string fee;
+        uint256 amount;
+        address token;
+    }
+
     struct QuoteResult {
         uint256 srcAmount;
-        uint256 dstAmount; // quoteOFT
+        uint256 amountReceivedLD;
         uint256 srcAmountMin;
         uint256 srcAmountMax;
         uint256 nativeFee;
         uint256 confirmations;
+        QuoteFee[] fees;
     }
 
     function sendOFT(

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -35,12 +35,17 @@ interface IOFTWrapper {
         address token;
     }
 
+    struct OFTQuoteResult {
+        QuoteResult quoteResult;
+        uint256 amountAfterWrapperFees;
+        uint256 fees;
+    }
+
     struct QuoteResult {
         uint256 srcAmount;
         uint256 amountReceivedLD;
         uint256 srcAmountMin;
         uint256 srcAmountMax;
-        uint256 nativeFee;
         uint256 confirmations;
         QuoteFee[] fees;
     }

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/epv2/MockOFT.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/epv2/MockOFT.sol
@@ -72,6 +72,8 @@ contract CustomQuoteOFTMockOFT is MockOFT {
     OFTLimit private oftLimit;
     MessagingFeeEpv2 private quoteSendFee;
 
+    uint256 public constant NATIVE_FEE_PRESENT = 1 ether; // Indicates native drop present
+
     function setQuoteOFTReturnValues(OFTReceipt memory _receipt, OFTLimit memory _limit) public {
         oftReceipt = _receipt;
         oftLimit = _limit;
@@ -88,9 +90,12 @@ contract CustomQuoteOFTMockOFT is MockOFT {
     }
 
     function quoteSend(
-        SendParamEpv2 calldata /*_sendParam*/,
+        SendParamEpv2 calldata _sendParam,
         bool /*_payInLzToken*/
-    ) external view virtual override returns (MessagingFeeEpv2 memory) {
+    ) external view override returns (MessagingFeeEpv2 memory) {
+        if (_sendParam.extraOptions.length != 0) {
+            return MessagingFeeEpv2(NATIVE_FEE_PRESENT, 0);
+        }
         return quoteSendFee;
     }
 }


### PR DESCRIPTION
@DanL0 
Looking for feedback in general but would be great to get your opinion on how to test the edge case where
```
                if (_input._nativeDrop != 0) {
                    require(_input._nativeDrop <= type(uint128).max, "OFTWrapper: nativeDrop exceeds uint128 max");
                    options = OptionsBuilder.newOptions().addExecutorNativeDropOption(
                        uint128(_input._nativeDrop),
                        _input._toAddress
                    );
                }
```
Currently I have a very hacky way of testing this using a Mock. I tried the whole day to find a better way and the only other way I could think of was decoding the options array. However that is a lot of work (unless there is a method that easily does this) and the current solution I have is good enough to test that options are created when native drop is > 0.

I figured I would ask your opinion before going deeper down the road of trying to decode options and then retrieve the nativeDrop from it and check that it is the correct value.